### PR TITLE
Decouple `Label` and `TextColorStyle`

### DIFF
--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/LabelDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/LabelDemoController.swift
@@ -30,6 +30,24 @@ class LabelDemoController: DemoController {
             textColorLabels.append(addLabel(text: colorStyle.description, style: .body1, colorStyle: colorStyle))
         }
 
+        addLabel(text: "Text Color Custom Styles", style: .body1Strong, colorStyle: .regular).textAlignment = .center
+
+        let dangerSuccessLabel = Label(textStyle: .body1Strong, colorForTheme: {
+            theme in
+            UIColor(light: theme.color(.dangerForeground1), dark: theme.color(.successBackground2))
+        })
+        dangerSuccessLabel.text = "Danger/Success"
+        container.addArrangedSubview(dangerSuccessLabel)
+        textColorLabels.append(dangerSuccessLabel)
+
+        let blueYellowLabel = Label(textStyle: .body1Strong, colorForTheme: {
+            _ in
+            UIColor(light: GlobalTokens.sharedColor(.blue, .primary), dark: GlobalTokens.sharedColor(.yellow, .primary))
+        })
+        blueYellowLabel.text = "Blue/Yellow"
+        container.addArrangedSubview(blueYellowLabel)
+        textColorLabels.append(blueYellowLabel)
+
         container.addArrangedSubview(UIView())  // spacer
 
         NotificationCenter.default.addObserver(self, selector: #selector(handleContentSizeCategoryDidChange), name: UIContentSizeCategory.didChangeNotification, object: nil)

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/LabelDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/LabelDemoController.swift
@@ -58,7 +58,7 @@ class LabelDemoController: DemoController {
         let label = Label(textStyle: style, colorStyle: colorStyle)
         label.text = text
         label.numberOfLines = 0
-        if colorStyle == .white || colorStyle == .secondaryOnColor {
+        if colorStyle == .white {
             label.backgroundColor = .black
         }
         container.addArrangedSubview(label)
@@ -82,8 +82,6 @@ extension TextColorStyle {
             return "Regular"
         case .secondary:
             return "Secondary"
-        case .secondaryOnColor:
-            return "Secondary on Color"
         case .white:
             return "White"
         case .primary:

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/LabelDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/LabelDemoController.swift
@@ -40,7 +40,7 @@ class LabelDemoController: DemoController {
         let label = Label(textStyle: style, colorStyle: colorStyle)
         label.text = text
         label.numberOfLines = 0
-        if colorStyle == .white {
+        if colorStyle == .white || colorStyle == .secondaryOnColor {
             label.backgroundColor = .black
         }
         container.addArrangedSubview(label)

--- a/ios/FluentUI/Label/Label.swift
+++ b/ios/FluentUI/Label/Label.swift
@@ -10,8 +10,17 @@ import UIKit
 /// By default, `adjustsFontForContentSizeCategory` is set to true to automatically update its font when device's content size category changes
 @objc(MSFLabel)
 open class Label: UILabel, TokenizedControlInternal {
-    @objc open var colorStyle: TextColorStyle = .regular {
-        didSet {
+    private static let defaultColorForTheme: (FluentTheme) -> UIColor = TextColorStyle.regular.uiColor
+
+    private var colorForTheme: (FluentTheme) -> UIColor = Label.defaultColorForTheme
+
+    @objc open var colorStyle: TextColorStyle {
+        @available(*, unavailable)
+        get {
+            preconditionFailure("colorStyle will be deprecated soon. Use color tokens directly.")
+        }
+        set {
+            colorForTheme = newValue.uiColor
             updateTextColor()
         }
     }
@@ -80,8 +89,8 @@ open class Label: UILabel, TokenizedControlInternal {
     lazy public var tokenSet: LabelTokenSet = .init(textStyle: { [weak self] in
         return self?.textStyle ?? .body1
     },
-                                                    colorStyle: { [weak self] in
-        return self?.colorStyle ?? .regular
+                                                    colorForTheme: { [weak self] theme in
+        return (self?.colorForTheme ?? Self.defaultColorForTheme)(theme)
     })
 
     @objc convenience public init() {

--- a/ios/FluentUI/Label/Label.swift
+++ b/ios/FluentUI/Label/Label.swift
@@ -12,8 +12,6 @@ import UIKit
 open class Label: UILabel, TokenizedControlInternal {
     private static let defaultColorForTheme: (FluentTheme) -> UIColor = TextColorStyle.regular.uiColor
 
-    private var colorForTheme: (FluentTheme) -> UIColor = Label.defaultColorForTheme
-
     @objc open var colorStyle: TextColorStyle {
         @available(*, unavailable)
         get {
@@ -92,6 +90,8 @@ open class Label: UILabel, TokenizedControlInternal {
                                                     colorForTheme: { [weak self] theme in
         return (self?.colorForTheme ?? Self.defaultColorForTheme)(theme)
     })
+
+    private var colorForTheme: (FluentTheme) -> UIColor = Label.defaultColorForTheme
 
     @objc convenience public init() {
         self.init(textStyle: .body1, colorStyle: .regular)

--- a/ios/FluentUI/Label/Label.swift
+++ b/ios/FluentUI/Label/Label.swift
@@ -17,7 +17,7 @@ open class Label: UILabel, TokenizedControlInternal {
     @objc open var colorStyle: TextColorStyle {
         @available(*, unavailable)
         get {
-            preconditionFailure("colorStyle will be deprecated soon. Use color tokens directly.")
+            preconditionFailure("colorStyle is now a write-only property")
         }
         set {
             colorForTheme = newValue.uiColor
@@ -108,6 +108,13 @@ open class Label: UILabel, TokenizedControlInternal {
         super.init(frame: .zero)
         self.textStyle = textStyle
         self.colorStyle = colorStyle
+        initialize()
+    }
+
+    @objc public init(textStyle: FluentTheme.TypographyToken = .body1, colorForTheme: @escaping (FluentTheme) -> UIColor) {
+        super.init(frame: .zero)
+        self.textStyle = textStyle
+        self.colorForTheme = colorForTheme
         initialize()
     }
 

--- a/ios/FluentUI/Label/LabelTokenSet.swift
+++ b/ios/FluentUI/Label/LabelTokenSet.swift
@@ -41,11 +41,16 @@ public class LabelTokenSet: ControlTokenSet<LabelTokenSet.Tokens> {
         case textColor
     }
 
+    convenience init(textStyle: @escaping () -> FluentTheme.TypographyToken,
+                     colorStyle: @escaping () -> TextColorStyle) {
+        self.init(textStyle: textStyle, colorForTheme: { colorStyle().uiColor(fluentTheme: $0) })
+    }
+
     init(textStyle: @escaping () -> FluentTheme.TypographyToken,
-         colorStyle: @escaping () -> TextColorStyle) {
+         colorForTheme: @escaping (FluentTheme) -> UIColor) {
         self.textStyle = textStyle
-        self.colorStyle = colorStyle
-        super.init { [colorStyle] token, theme in
+        self.colorForTheme = colorForTheme
+        super.init { [colorForTheme] token, theme in
             switch token {
             case .font:
                 return .uiFont {
@@ -53,7 +58,7 @@ public class LabelTokenSet: ControlTokenSet<LabelTokenSet.Tokens> {
                 }
             case .textColor:
                 return .uiColor {
-                    colorStyle().uiColor(fluentTheme: theme)
+                    return colorForTheme(theme)
                 }
             }
         }
@@ -61,6 +66,6 @@ public class LabelTokenSet: ControlTokenSet<LabelTokenSet.Tokens> {
 
     /// Defines the text typography style of the label.
     var textStyle: () -> FluentTheme.TypographyToken
-    /// Defines the text color style of the label.
-    var colorStyle: () -> TextColorStyle
+    /// Defines the text color style of the label for a given theme.
+    var colorForTheme: (FluentTheme) -> UIColor
 }

--- a/ios/FluentUI/Label/LabelTokenSet.swift
+++ b/ios/FluentUI/Label/LabelTokenSet.swift
@@ -15,6 +15,24 @@ public enum TextColorStyle: Int, CaseIterable {
     case white
     case primary
     case error
+
+    func uiColor(fluentTheme: FluentTheme) -> UIColor {
+        switch self {
+        case .regular:
+            return fluentTheme.color(.foreground1)
+        case .secondary:
+            return fluentTheme.color(.foreground2)
+        case .secondaryOnColor:
+            return UIColor(light: fluentTheme.color(.foregroundOnColor),
+                           dark: fluentTheme.color(.foreground2))
+        case .white:
+            return fluentTheme.color(.foregroundLightStatic)
+        case .primary:
+            return fluentTheme.color(.brandForeground1)
+        case .error:
+            return fluentTheme.color(.dangerForeground2)
+        }
+    }
 }
 
 public class LabelTokenSet: ControlTokenSet<LabelTokenSet.Tokens> {
@@ -35,21 +53,7 @@ public class LabelTokenSet: ControlTokenSet<LabelTokenSet.Tokens> {
                 }
             case .textColor:
                 return .uiColor {
-                    switch colorStyle() {
-                    case .regular:
-                        return theme.color(.foreground1)
-                    case .secondary:
-                        return theme.color(.foreground2)
-                    case .secondaryOnColor:
-                        return UIColor(light: theme.color(.foregroundOnColor),
-                                       dark: theme.color(.foreground2))
-                    case .white:
-                        return theme.color(.foregroundLightStatic)
-                    case .primary:
-                        return theme.color(.brandForeground1)
-                    case .error:
-                        return theme.color(.dangerForeground2)
-                    }
+                    colorStyle().uiColor(fluentTheme: theme)
                 }
             }
         }

--- a/ios/FluentUI/Label/LabelTokenSet.swift
+++ b/ios/FluentUI/Label/LabelTokenSet.swift
@@ -11,7 +11,6 @@ import UIKit
 public enum TextColorStyle: Int, CaseIterable {
     case regular
     case secondary
-    case secondaryOnColor
     case white
     case primary
     case error
@@ -22,9 +21,6 @@ public enum TextColorStyle: Int, CaseIterable {
             return fluentTheme.color(.foreground1)
         case .secondary:
             return fluentTheme.color(.foreground2)
-        case .secondaryOnColor:
-            return UIColor(light: fluentTheme.color(.foregroundOnColor),
-                           dark: fluentTheme.color(.foreground2))
         case .white:
             return fluentTheme.color(.foregroundLightStatic)
         case .primary:

--- a/ios/FluentUI/TwoLineTitleView/TwoLineTitleView.swift
+++ b/ios/FluentUI/TwoLineTitleView/TwoLineTitleView.swift
@@ -343,10 +343,6 @@ open class TwoLineTitleView: UIView, TokenizedControlInternal {
     // MARK: Highlighting
 
     private func applyStyle() {
-        // Reset color styles since they might have changed
-        //titleLabel.colorStyle = TokenSetType.defaultTitleColorStyle(for: currentStyle)
-        //subtitleLabel.colorStyle = TokenSetType.defaultSubtitleColorStyle(for: currentStyle)
-
         titleLabel.tokenSet.setOverrides(from: tokenSet, mapping: [.textColor: .titleColor])
         let titleColor = titleLabel.tokenSet[.textColor].uiColor
         titleLeadingImageView.tintColor = titleColor

--- a/ios/FluentUI/TwoLineTitleView/TwoLineTitleView.swift
+++ b/ios/FluentUI/TwoLineTitleView/TwoLineTitleView.swift
@@ -171,7 +171,7 @@ open class TwoLineTitleView: UIView, TokenizedControlInternal {
     private let subtitleContainer: UIStackView
 
     private lazy var titleLabel: Label = {
-        let label = Label(textStyle: TokenSetType.defaultTitleFont)
+        let label = Label(textStyle: TokenSetType.defaultTitleFont, colorForTheme: { _ in self.tokenSet[.titleColor].uiColor })
         label.lineBreakMode = .byTruncatingTail
         label.textAlignment = .center
         return label
@@ -181,7 +181,7 @@ open class TwoLineTitleView: UIView, TokenizedControlInternal {
     private var titleTrailingImageView = UIImageView()
 
     private lazy var subtitleLabel: Label = {
-        let label = Label(textStyle: TokenSetType.defaultSubtitleFont)
+        let label = Label(textStyle: TokenSetType.defaultSubtitleFont, colorForTheme: { _ in self.tokenSet[.subtitleColor].uiColor })
         label.lineBreakMode = .byTruncatingMiddle
         return label
     }()
@@ -334,8 +334,8 @@ open class TwoLineTitleView: UIView, TokenizedControlInternal {
 
     private func applyStyle() {
         // Reset color styles since they might have changed
-        titleLabel.colorStyle = TokenSetType.defaultTitleColorStyle(for: currentStyle)
-        subtitleLabel.colorStyle = TokenSetType.defaultSubtitleColorStyle(for: currentStyle)
+        //titleLabel.colorStyle = TokenSetType.defaultTitleColorStyle(for: currentStyle)
+        //subtitleLabel.colorStyle = TokenSetType.defaultSubtitleColorStyle(for: currentStyle)
 
         titleLabel.tokenSet.setOverrides(from: tokenSet, mapping: [.textColor: .titleColor])
         let titleColor = titleLabel.tokenSet[.textColor].uiColor

--- a/ios/FluentUI/TwoLineTitleView/TwoLineTitleViewTokenSet.swift
+++ b/ios/FluentUI/TwoLineTitleView/TwoLineTitleViewTokenSet.swift
@@ -23,7 +23,6 @@ public class TwoLineTitleViewTokenSet: ControlTokenSet<TwoLineTitleViewTokenSet.
 
     init(style: @escaping () -> TwoLineTitleView.Style) {
         super.init { [style] token, theme in
-            assertionFailure("TwoLineTitleView is a compound control, so we shouldn't be accessing its default token values directly")
             switch token {
             case .subtitleColor:
                 return .uiColor {
@@ -67,24 +66,6 @@ extension TwoLineTitleViewTokenSet {
 
     static let defaultTitleFont: FluentTheme.TypographyToken = .body1Strong
     static let defaultSubtitleFont: FluentTheme.TypographyToken = .caption1
-
-    static func defaultTitleColorStyle(for style: TwoLineTitleView.Style) -> TextColorStyle {
-        switch style {
-        case .primary:
-            return .white // Equivalent to .foregroundOnColor on light, .foreground1 on dark
-        case .system:
-            return .regular
-        }
-    }
-
-    static func defaultSubtitleColorStyle(for style: TwoLineTitleView.Style) -> TextColorStyle {
-        switch style {
-        case .primary:
-            return .secondaryOnColor // Equivalent to .foregroundColor on light, .foreground2 on dark
-        case .system:
-            return .secondary
-        }
-    }
 
     static let minimumTouchSize: CGSize = EasyTapButton.minimumTouchSize
 


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

*NOTE: This is currently targeted for new-2ltv, but it will be merged directly into the branch that's part of microsoft#1731 after #1 makes it in.*

The discussion of microsoft#1731 uncovered [a bug](https://github.com/microsoft/fluentui-apple/pull/1731#discussion_r1186563591) where label tokens don't always play nicely when placed inside parent components. The ultimate problem here is that right now, a `Label` *must* be defined in terms of a `TextColorStyle`. This not only limits what we and consumers of FUA can do with `Label`s, but it's also an unnecessary abstraction since we usually specify labels in terms of individual typography styles and colors.

Our solution is to make it such that `Label` is more closely connected to `UIColor`. This gives us more flexibility in terms of what colors a label can be. It also removes the need for `TextColorStyle.secondaryOnColor`, which we needed to add as a special case for `TwoLineTitleView`.

Note that we specify the color as a `(FluentTheme) -> UIColor` instead of just a `UIColor` because brand colors (as opposed to neutral colors like "Grey 42" and shared colors like "Blue Primary") require a theme in order to be translatable to a `UIColor`. See the usage in LabelDemoController.swift for an example.

### Verification

(how the change was tested, including both manual and automated tests)

<details>
<summary>Visual Verification</summary>

| Light mode | Dark mode | Token override* |
|---|---|---|
| ![Simulator Screen Shot - iPhone 14 Pro - 2023-05-11 at 13 30 39](https://github.com/amgleitman/fluentui-apple/assets/717674/a25b1e45-3dd1-4d18-b6ca-6275f0fb60d1) | ![Simulator Screen Shot - iPhone 14 Pro - 2023-05-11 at 13 30 43](https://github.com/amgleitman/fluentui-apple/assets/717674/7de79a48-791e-49c4-9c7f-0ecb0785e7fa) | ![Simulator Screen Shot - iPhone 14 Pro - 2023-05-11 at 13 30 25](https://github.com/amgleitman/fluentui-apple/assets/717674/c3c345b5-ae58-4566-ac3e-9f9da7217a92) |

*This was created by manually changing `TwoLineTitleViewTokenSet` to show `UIColor.systemRed` for the title and `UIColor.systemOrange` for the subtitle. This obviously isn't part of the change, but it's proof of concept that it works.

</details>

### Pull request checklist

This PR has considered:
- [x] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)